### PR TITLE
chore: upgrade filecoin api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5550,9 +5550,9 @@
       }
     },
     "node_modules/@web3-storage/filecoin-api": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-4.0.3.tgz",
-      "integrity": "sha512-1UtILTwnRH8V0IuLErhmWqXKrBwXOwPlBVmzLmlt3Ru5SHGB3PSe9PWBB/nvWv9MZJxJRSxEuvAPIpLqNWLyuw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@web3-storage/filecoin-api/-/filecoin-api-4.0.4.tgz",
+      "integrity": "sha512-SJAdtiup9J1r88EImAoalEhh4nBC1TCIzaUsfpAfWqS2ziuTaX0FJTnw54Tz/2G1IEI4y7rnd1vmf1lQdVl3HQ==",
       "dependencies": {
         "@ipld/dag-ucan": "^3.4.0",
         "@ucanto/client": "^9.0.0",
@@ -15248,7 +15248,7 @@
         "@ucanto/transport": "^9.0.0",
         "@web3-storage/capabilities": "^11.1.0",
         "@web3-storage/data-segment": "^4.0.0",
-        "@web3-storage/filecoin-api": "^4.0.3",
+        "@web3-storage/filecoin-api": "^4.0.4",
         "@web3-storage/filecoin-client": "^3.0.1",
         "multiformats": "12.0.1",
         "p-retry": "^5.1.2",
@@ -15415,7 +15415,7 @@
         "@ucanto/server": "^9.0.1",
         "@ucanto/transport": "^9.0.0",
         "@w3filecoin/core": "*",
-        "@web3-storage/filecoin-api": "^4.0.3",
+        "@web3-storage/filecoin-api": "^4.0.4",
         "@web3-storage/filecoin-client": "3.0.1",
         "uint8arrays": "^4.0.6"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "@ucanto/transport": "^9.0.0",
     "@web3-storage/capabilities": "^11.1.0",
     "@web3-storage/data-segment": "^4.0.0",
-    "@web3-storage/filecoin-api": "^4.0.3",
+    "@web3-storage/filecoin-api": "^4.0.4",
     "@web3-storage/filecoin-client": "^3.0.1",
     "multiformats": "12.0.1",
     "uint8arrays": "^4.0.4",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -11,7 +11,7 @@
     "@ucanto/core": "^9.0.0",
     "@ucanto/server": "^9.0.1",
     "@ucanto/transport": "^9.0.0",
-    "@web3-storage/filecoin-api": "^4.0.3",
+    "@web3-storage/filecoin-api": "^4.0.4",
     "@web3-storage/filecoin-client": "3.0.1",
     "@w3filecoin/core": "*"
   },

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -309,5 +309,5 @@ test('POST /', async t => {
 function getDealerOfferStoreKey (record) {
   return `${new Date(
     record.insertedAt
-  ).toISOString()} ${record.aggregate.toString()}.json`
+  ).toISOString()}_${record.aggregate.toString()}.json`
 }


### PR DESCRIPTION
drop space out of key name for dealer offer store