### PR TITLE
fix: spade oracle sync with log2size to height conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15172,7 +15172,7 @@
         "@ucanto/server": "^9.0.1",
         "@ucanto/transport": "^9.0.0",
         "@web3-storage/capabilities": "^11.1.0",
-        "@web3-storage/data-segment": "^4.0.0",
+        "@web3-storage/data-segment": "^5.0.0",
         "@web3-storage/filecoin-api": "^4.0.4",
         "@web3-storage/filecoin-client": "^3.0.1",
         "fzstd": "^0.1.0",
@@ -15249,8 +15249,9 @@
       }
     },
     "packages/core/node_modules/@web3-storage/data-segment": {
-      "version": "4.0.0",
-      "license": "(Apache-2.0 AND MIT)",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@web3-storage/data-segment/-/data-segment-5.0.0.tgz",
+      "integrity": "sha512-5CbElsxec2DsKhEHEh3XRGISAyna+bCjKjjvFrLcYyXLCaiSt/nF3ypcllxwjpE4newMUArymGKGzzZnRWL2kg==",
       "dependencies": {
         "@ipld/dag-cbor": "^9.0.5",
         "multiformats": "^11.0.2",
@@ -15413,6 +15414,7 @@
       }
     },
     "packages/tools": {
+      "name": "@w3filecoin/tools",
       "version": "0.0.0",
       "devDependencies": {
         "@ipld/dag-ucan": "3.4.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "@ucanto/server": "^9.0.1",
     "@ucanto/transport": "^9.0.0",
     "@web3-storage/capabilities": "^11.1.0",
-    "@web3-storage/data-segment": "^4.0.0",
+    "@web3-storage/data-segment": "^5.0.0",
     "@web3-storage/filecoin-api": "^4.0.4",
     "@web3-storage/filecoin-client": "^3.0.1",
     "fzstd": "^0.1.0",

--- a/packages/core/src/deal-tracker/spade-oracle-sync-tick.js
+++ b/packages/core/src/deal-tracker/spade-oracle-sync-tick.js
@@ -244,6 +244,6 @@ export function convertPieceCidV1toPieceCidV2 (link, height) {
  * 
  * @param {number} log2Size 
  */
-function log2PieceSizeToHeight (log2Size) {
-  return Piece.Size.Expanded.toHeight(BigInt(log2Size))
+export function log2PieceSizeToHeight (log2Size) {
+  return Piece.Size.Expanded.toHeight(2n ** BigInt(log2Size))
 }

--- a/packages/core/src/deal-tracker/spade-oracle-sync-tick.js
+++ b/packages/core/src/deal-tracker/spade-oracle-sync-tick.js
@@ -210,7 +210,7 @@ async function fetchLatestDealArchive (spadeOracleUrl) {
     // Convert PieceCidV1 to PieceCidV2
     const pieceCid = convertPieceCidV1toPieceCidV2(
       parseLink(replica.piece_cid),
-      replica.piece_log2_size
+      log2PieceSizeToHeight(replica.piece_log2_size)
     )
     dealMap.set(pieceCid.toString(), replica.contracts.map(c => ({
       provider: c.provider_id,
@@ -238,4 +238,12 @@ export function convertPieceCidV1toPieceCidV2 (link, height) {
   })
 
   return piece.link
+}
+
+/**
+ * 
+ * @param {number} log2Size 
+ */
+function log2PieceSizeToHeight (log2Size) {
+  return Piece.Size.Expanded.toHeight(BigInt(log2Size))
 }

--- a/packages/core/test/deal-tracker/spade-oracle-sync.test.js
+++ b/packages/core/test/deal-tracker/spade-oracle-sync.test.js
@@ -206,6 +206,10 @@ test('converts PieceCidV1 to PieceCidV2', t => {
   t.falsy(pieceCidV1.equals(pieceCidV2))
 })
 
+test('converts log2pieceSize to height', t => {
+  const height = spadeOracleSyncTick.log2PieceSizeToHeight(35)
+  t.is(height, 30)
+})
 /**
  * @param {string} source 
  */

--- a/packages/functions/src/deal-tracker-api/ucan-invocation-router.js
+++ b/packages/functions/src/deal-tracker-api/ucan-invocation-router.js
@@ -102,7 +102,7 @@ function getLambdaEnv () {
   return {
     did: mustGetEnv('DID'),
     ucanLogUrl: mustGetEnv('UCAN_LOG_URL'),
-    dealStoreTableName: Table['deal-tracker-deal-store'],
+    dealStoreTableName: Table['deal-tracker-deal-store-v1'],
     dealStoreTableRegion: mustGetEnv('AWS_REGION'),
   }
 }

--- a/packages/functions/src/deal-tracker/spade-oracle-sync-tick.js
+++ b/packages/functions/src/deal-tracker/spade-oracle-sync-tick.js
@@ -59,7 +59,7 @@ function getLambdaEnv () {
   return {
     dealArchiveStoreBucketName: mustGetEnv('DEAL_ARCHIVE_STORE_BUCKET_NAME'),
     dealArchiveStoreBucketRegion: mustGetEnv('DEAL_ARCHIVE_STORE_REGION'),
-    dealStoreTableName: Table['deal-tracker-deal-store'],
+    dealStoreTableName: Table['deal-tracker-deal-store-v1'],
     dealStoreTableRegion: mustGetEnv('AWS_REGION'),
     spadeOracleUrl: mustGetEnv('SPADE_ORACLE_URL'),
   }

--- a/packages/functions/src/types.ts
+++ b/packages/functions/src/types.ts
@@ -24,7 +24,7 @@ declare module 'sst/node/table' {
     'aggregator-inclusion-store': {
       tableName: string;
     };
-    'deal-tracker-deal-store': {
+    'deal-tracker-deal-store-v1': {
       tableName: string;
     };
     'dealer-aggregate-store': {

--- a/stacks/data-stack.js
+++ b/stacks/data-stack.js
@@ -112,7 +112,7 @@ export function DataStack({ stack, app }) {
   /**
    * Deal archive store used to store active replicas reported by Spade Oracle.
    */
-  const dealTrackerDealArchiveBucket = getBucketConfig('deal-tracker-deal-archive-store', stack.stage)
+  const dealTrackerDealArchiveBucket = getBucketConfig('deal-tracker-deal-archive-store', stack.stage, 1)
   const dealTrackerDealArchiveStoreBucket = new Bucket(stack, dealTrackerDealArchiveBucket.bucketName, {
     cors: true,
     cdk: {
@@ -123,7 +123,7 @@ export function DataStack({ stack, app }) {
   /**
    * Deal store used to store deal information 
    */
-  const dealTrackerDealStoreTableName = 'deal-tracker-deal-store'
+  const dealTrackerDealStoreTableName = 'deal-tracker-deal-store-v1'
   const dealTrackerDealStoreTable = new Table(stack, dealTrackerDealStoreTableName, {
     ...dealStoreTableProps,
     // information that will be written to the stream

--- a/test/helpers/deployment.js
+++ b/test/helpers/deployment.js
@@ -115,7 +115,7 @@ export const getStoreClients = () => {
     },
     tracker: {
       dealStore: createDealTrackerDealStoreClient(dynamoClient,
-        { tableName: getTableName(`deal-tracker-deal-store`) }
+        { tableName: getTableName(`deal-tracker-deal-store-v1`) }
       )
     }
   }


### PR DESCRIPTION
Actually assumption that `piece_log2_size` was height was bad, which resulted in a mismatch on generated PieceCidv2 from PieceCidV1 we get from spade, which would not match to new deals for the dealer aggregates and receipts issued

Note that new bucket and DB are created given tear down the old DB and Bucket is way cheaper than running Dynamo delete commands for every single record in the table