### PR TITLE
fix: tweak timeouts for aggregator and drop unnecessary check on buffering

### DIFF
--- a/packages/functions/src/aggregator/handle-buffer-queue-message.js
+++ b/packages/functions/src/aggregator/handle-buffer-queue-message.js
@@ -24,15 +24,6 @@ Sentry.AWSLambda.init({
  * @param {import('aws-lambda').SQSEvent} sqsEvent
  */
 async function handleBufferQueueMessage (sqsEvent) {
-  // if one we should put back in queue
-  if (sqsEvent.Records.length === 1) {
-    return {
-      batchItemFailures: sqsEvent.Records.map(r => ({
-        itemIdentifier: r.messageId
-      }))
-    }
-  }
-
   // unexpected number of records
   if (sqsEvent.Records.length !== 2) {
     return {

--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -139,7 +139,8 @@ export function AggregatorStack({ stack, app }) {
         permissions: [
           aggregatorBufferStoreBucket,
           bufferQueue
-        ]
+        ],
+        timeout: '20 seconds'
       },
       deadLetterQueue: aggregatorPieceStoreHandleInsertDLQ.cdk.queue,
       cdk: {
@@ -188,7 +189,8 @@ export function AggregatorStack({ stack, app }) {
         bufferQueue,
         aggregatorBufferStoreBucket,
         aggregateOfferQueue
-      ]
+      ],
+      timeout: '20 seconds'
     },
     deadLetterQueue: bufferQueueDLQ.cdk.queue,
     cdk: {
@@ -243,7 +245,7 @@ export function AggregatorStack({ stack, app }) {
           aggregatorBufferStoreBucket,
           pieceAcceptQueue
         ],
-        timeout: '10 minutes'
+        timeout: '5 minutes'
       },
       deadLetterQueue: aggregatorAggregateStoreHandleInsertToPieceAcceptDLQ.cdk.queue,
       cdk: {


### PR DESCRIPTION
Over last 2 weeks, 3 pieces did not make it to an aggregate. They were received and written into PieceStore, but their insertion did not put them into a Buffer to be reduced and aggregated. This seems a edge case and happened over a week ago. I suspect that this may be related to `batchItemFailures` usage having some extra configurations we are not using. Probably we would need to configure something else on (On-failure destination):

<img width="426" alt="image" src="https://github.com/web3-storage/w3filecoin-infra/assets/7295071/accaee29-0840-49ac-a56b-d593a9910e6a">

Therefore, decided to just drop this, as we can rely on the `length !== 2` to fail anyway and retry after.

Also tweaked some timeouts based on my observations of errors in the lambdas over the last 2 weeks based on timeouts