### PR TITLE
fix: set aggregator handle buffer queue message timeout and memory per env set in aws console

### DIFF
--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -69,9 +69,10 @@ export function AggregatorStack({ stack, app }) {
         // During the deduplication interval (5 minutes), Amazon SQS treats
         // messages that are sent with identical body content
         contentBasedDeduplication: true,
-        queueName: `${bufferQueueName}.fifo`
+        queueName: `${bufferQueueName}.fifo`,
+        visibilityTimeout: Duration.minutes(2)
       }
-    }
+    },
   })
 
   /**

--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -190,7 +190,8 @@ export function AggregatorStack({ stack, app }) {
         aggregatorBufferStoreBucket,
         aggregateOfferQueue
       ],
-      timeout: '20 seconds'
+      timeout: '2 minutes',
+      memorySize: '2 GB'
     },
     deadLetterQueue: bufferQueueDLQ.cdk.queue,
     cdk: {


### PR DESCRIPTION
We set these in https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/prod-w3filecoin-Aggregato-Consumerprodw3filecoinbu-eABNpWfR98KT?tab=configure to make pipeline not stall when a large influx of small pieces make it to the pipeline, which was making the timeout being triggered (first for 20s, and then for 40s after manually swapped in the UI). Since then, we updated memory and timeout to 2min.

While we do not do a profiling on aggregate builder and buffering algorithms, we should keep these new values so making PR in case a new deployment overrides values defined in console