### PR TITLE
fix: deal time monitor aggregate threshold verification

### DIFF
--- a/packages/core/src/monitor/deal-monitor-alert-tick.js
+++ b/packages/core/src/monitor/deal-monitor-alert-tick.js
@@ -41,8 +41,8 @@ export async function dealMonitorAlertTick (context) {
   const currentTime = Date.now()
   for (const offeredAggregate of offeredAggregates.ok) {
     const offerTime = (new Date(offeredAggregate.insertedAt)).getTime()
-    // Monitor if offer time + monitor threshold is bigger than current time
-    if (offerTime + context.aggregateMonitorThresholdMs > currentTime) {
+    // Monitor if current time is bigger than offer time + monitor threshold
+    if (currentTime > (offerTime + context.aggregateMonitorThresholdMs)) {
       offeredAggregatesToMonitor.push(offeredAggregate)
     }
   }


### PR DESCRIPTION
There was a bug in monitoring code. Basically condition was preventing everything from getting fired. Details follow

We have 3 main variables:
- AGGREGATE_MONITOR_THRESHOLD_MS - number of ms an aggregate can be in the pipeline without checking state
- MIN_PIECE_CRITICAL_THRESHOLD_MS - number if ms a piece can be pending a deal until critical alert
- MIN_PIECE_WARN_THRESHOLD_MS - number if ms a piece can be pending a deal until warn alert

With these variables we do:
1. get all the aggregates pending deals from DB
2. filter the aggregates that are already more than `AGGREGATE_MONITOR_THRESHOLD_MS` pending
3. grab filtered aggregates oldest piece in the pipeline information
4. check if their age in the pipeline should trigger warn or critical alerts

we were failing on step 2, and doing the comparison the other way around. So, we would filter out the aggregates that we should actually inspect. The aggregates that we would analyse were the ones that actually were recent, and therefore no alerts