### PR TITLE
fix: buffer reduce lambda with bigger batch size

### DIFF
--- a/stacks/aggregator-stack.js
+++ b/stacks/aggregator-stack.js
@@ -197,8 +197,9 @@ export function AggregatorStack({ stack, app }) {
     deadLetterQueue: bufferQueueDLQ.cdk.queue,
     cdk: {
       eventSource: {
-        // as soon as we have 2, we can act fast and reduce to see if enough bytes
-        batchSize: 2,
+        // we can reduce most buffers possible at same time to avoid large buffers to create huge congestion on the queue while being processed.
+        // also makes less lambda calls and decreases overall execution time.
+        batchSize: 10,
         // allow reporting partial failures
         reportBatchItemFailures: true,
       },


### PR DESCRIPTION
we made buffering lambda to be kicked once we have a max batch size of 2. The goal here was to as soon as we have a 2 items in queue already buffer them in order to work as fast as possible. This proved to be problematic in this case… If we end up with a crazily large number of pieces in a batch (like 10k pieces), every time we run the lambda it will take over 120 seconds to concatenate it with the other buffer in the batch. What I observed was that we would usually have one super big batch and other considerably small, which was leading to a lot of super long lambda runs just to add a handful of pieces to the batch. This resulted in a high congestion in the queue
=> I propose that we simply bump this batch size to 10 (max for a FIFO QUEUE). We still rely on the max window timeout to trigger with smaller batch size, and avoid this scenarios. It will also mean way less runs, and for our upload rate I see continuously our queue with dozens of messages to handle, so this will actually make things faster overall

See https://filecoinproject.slack.com/archives/C06EDB1NADU/p1709749091674859